### PR TITLE
Update blind

### DIFF
--- a/blind
+++ b/blind
@@ -104,7 +104,7 @@ c=0
 for x in blinds:
    c+=1
    if bln==x:
-      blind='000'+str(c)
+      blind='000'+format(c, 'x')
 
 if bln=='all':
    blind='0000'


### PR DESCRIPTION
Blind number is hexadecimal instead of decimal.  The change on this line fixes a bug when you have more than 9 devices in your Connector account (my case due to blinds randomly disappearing... when I add them again, the "lost" blinds are somehow there for the API but not the Connector app).